### PR TITLE
convert values of `vim.current.buffer` to bytes first

### DIFF
--- a/pythonx/completor/__init__.py
+++ b/pythonx/completor/__init__.py
@@ -171,7 +171,8 @@ class Completor(Base):
             'line': line - 1,
             'col': col,
             'filename': self.filename,
-            'content': to_unicode(b'\n'.join(vim.current.buffer[:]),
+            'content': to_unicode(b'\n'.join([to_bytes(s, get_encoding())
+                                              for s in vim.current.buffer[:]]),
                                   get_encoding())
         })
 


### PR DESCRIPTION
The plugin didn't work on my machine (Arch Linux, VIM + python3 + python-jedi). For some unknown reason `vim.current.buffer` returns a list of `str` instead of `bytes`. Hence i convert them using the already provided `to_bytes` method. This fix should not have any side effects; hence it should be save to merge.

I wonder why no one else has run into this problem...

```
$ python --version
Python 3.5.2

$ vim --version
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Oct 26 2016 15:03:09)
Included patches: 1-46
Compiled by Arch Linux
```