### PR TITLE
cpp completer: Fix clang parameter on MSYS

### DIFF
--- a/pythonx/completers/cpp.py
+++ b/pythonx/completers/cpp.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+import os
 from completor import Completor
 from completor.compat import to_bytes
 
@@ -43,11 +44,17 @@ class Clang(Completor):
             '-I{}'.format(self.current_directory),
         ]
         args.extend(self.parse_config(self.args_file))
+        complatfile = tempfile
+        if os.getenv('MSYSTEM') != None:
+            cmd ='cygpath -a -w {}'.format(complatfile) 
+            complatfile = os.popen(cmd).read()
+            print(complatfile)
+            complatfile = complatfile.strip().replace('\\', '\\\\')
         args.extend([
             '-Xclang',
             '-code-completion-macros',
             '-Xclang',
-            '-code-completion-at={}:{}:{}'.format(tempfile, row, col + 1),
+            '-code-completion-at={}:{}:{}'.format(complatfile, row, col + 1),
             tempfile
         ])
         return args


### PR DESCRIPTION
On MSYS2, the parameter `-code-completion-at` expects the path to be in Windows path notation with espaced backslashes. This PR changes the cpp completer so it checks for an environment variable `MSYSTEM` and, if it exists, modifies the path accordingly. Converting the *NIX path to Windows is done with a external call to the cygpath tool that comes with msys2.