### PR TITLE
Use yarn if available to install tern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
+CHANGE_DIR = cd ./pythonx/completers/javascript && 
+HAS_YARN := $(shell which yarn)
+
 js:
-	cd ./pythonx/completers/javascript && npm install
+ifdef HAS_YARN
+	$(CHANGE_DIR) yarn install
+else
+	$(CHANGE_DIR) npm install
+endif
 
 
 .PHONY: js

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ let g:completor_racer_binary = '/path/to/racer'
 
 #### Javascript
 Use [tern](https://github.com/ternjs/tern) for completion. To install tern
-you must have node and npm installed. Then run:
+you must have node and either npm or yarn installed. Then run:
 
 ```bash
 make js


### PR DESCRIPTION
I don't have npm installed so I modified the makefile to detect yarn and use it if available. I'm not sure if this is the best approach.