### PR TITLE
Fix unwanted trigger in paste mode

### DIFF
--- a/autoload/completor.vim
+++ b/autoload/completor.vim
@@ -43,6 +43,9 @@ endfunction
 
 
 function! completor#trigger(msg)
+  if &paste!=0 || mode() != 'i'
+    return
+  endif
   let is_empty = v:false
   if !s:consistent()
     call s:completions.clear()


### PR DESCRIPTION
Currently completor may be triggered in `paste` mode, and this may conflicts with some plugin. For example, see this issue(https://github.com/roxma/vim-paste-easy/issues/7).  
User should use `paste` mode only when they are pasting stuff, so auto completion is not needed in such situation.     
BTW, I also check whether `insert` mode is used, according to this issue(https://github.com/roxma/nvim-completion-manager/issues/78).
