### PR TITLE
Fix vim8 hang when ch_status() == 'buffered' but ch_read returns nothing

### DIFF
--- a/autoload/completor/compat.vim
+++ b/autoload/completor/compat.vim
@@ -1,7 +1,11 @@
 function! s:vim_oneshot_handler(ch)
   let msg = []
   while ch_status(a:ch) ==# 'buffered'
-    call add(msg, ch_read(a:ch))
+    let chunk = ch_read(a:ch)
+    if strlen(chunk) == 0
+      break
+    endif
+    call add(msg, chunk)
   endwhile
   call completor#trigger(msg)
 endfunction


### PR DESCRIPTION
It seems that sometimes, the ch_status is buffered, but ch_read is
returning nothing. vim_oneshot_handler is stuck in an infinite loop.

Since this is happening in the main thread, vim appears to lockup until
you hit Ctrl+c or something to interrupt eval of this code.

Specifically, I've seen this when using the clang autocompletion on
C-like languages. If I was typing particularly fast, I would see this
issue occur. It was getting annoying.

I ran vim in GDB to try and figure out what was going
on, saw that it was evaling this code inside this function. I then added
logging to this function and confirmed that the problem was here.

Based on my understanding, it is safe to exit the loop early, you might
just not get all your completions...