### PR TITLE
Do not repeatedly overwrite completeopt setting

### DIFF
--- a/autoload/completor.vim
+++ b/autoload/completor.vim
@@ -60,12 +60,6 @@ function! completor#trigger(msg)
   if is_empty | return | endif
 
   setlocal completefunc=completor#completefunc
-  setlocal completeopt-=longest
-  setlocal completeopt+=menuone
-  setlocal completeopt-=menu
-  if &completeopt !~# 'noinsert\|noselect'
-    setlocal completeopt+=noselect
-  endif
   if get(g:, 'completor_auto_trigger', 1)
     call feedkeys("\<Plug>CompletorTrigger")
   endif


### PR DESCRIPTION
See #109.

Right now, a user can set `completeopt` and have the setting stick right up to the point where they use `completor#completefunc`, which has the side effect of overwriting those settings.

Unless I'm missing something (and this is quite possible!), this repeated overwriting of the user's `completeopt` setting is not integral to completor's functionality.

This diff enables a user to, e.g. `set completeopt=menu,preview` and have it stay that way.