### PR TITLE
Php support via. Phpactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ let g:completor_gocode_binary = '/path/to/gocode'
 
 Use [completor-swift](https://github.com/maralla/completor-swift).
 
+#### PHP
+
+Use [phpactor](https://github.com/phpactor/phpactor).
+
 #### other languages
 
 For other omni completions completor not natively implemented, auto completion

--- a/pythonx/completers/php.py
+++ b/pythonx/completers/php.py
@@ -9,30 +9,36 @@ from completor.compat import to_unicode
 
 class Php(Completor):
     filetype = 'php'
-    trigger = r'(?::\w{2,}\w*|->\w*)$'
+    trigger = r'(::\w*|->\w*)$'
 
     def offset(self):
         line, col = vim.current.window.cursor
         line2byte = vim.Function('line2byte')
-        return line2byte(line) + col - 3
+        return line2byte(line) + col - 1
 
     def format_cmd(self):
         binary = self.get_option('phpactor_binary') or 'phpactor'
         return [binary, 'complete', self.tempname, self.offset(), '--format=json']
 
     def parse(self, data):
+        if len(data) == 0:
+            return []
+
         res = []
         data = to_unicode(data[0], 'utf-8')
-        data = json.loads(data)
 
-        if 'error' in data:
-            pprint.pprint(data)
+        try:
+            data = json.loads(data)
+        except json.decoder.JSONDecodeError:
+            return []
+
+        if not 'suggestions' in data:
             return []
 
         for item in data['suggestions']:
             res.append({
                 'word': item['name'],
-                'menu': item['type']
+                'menu': item['info']
             })
 
         return res

--- a/pythonx/completers/php.py
+++ b/pythonx/completers/php.py
@@ -2,7 +2,6 @@
 
 import vim
 import json
-import pprint
 
 from completor import Completor
 from completor.compat import to_unicode

--- a/pythonx/completers/php.py
+++ b/pythonx/completers/php.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import vim
+import json
+import pprint
+
+from completor import Completor
+from completor.compat import to_unicode
+
+class Php(Completor):
+    filetype = 'php'
+    trigger = r'(?::\w{2,}\w*|->\w*)$'
+
+    def offset(self):
+        line, col = vim.current.window.cursor
+        line2byte = vim.Function('line2byte')
+        return line2byte(line) + col - 3
+
+    def format_cmd(self):
+        binary = self.get_option('phpactor_binary') or 'phpactor'
+        return [binary, 'complete', self.tempname, self.offset(), '--format=json']
+
+    def parse(self, data):
+        res = []
+        data = to_unicode(data[0], 'utf-8')
+        data = json.loads(data)
+
+        if 'error' in data:
+            pprint.pprint(data)
+            return []
+
+        for item in data['suggestions']:
+            res.append({
+                'word': item['name'],
+                'menu': item['type']
+            })
+
+        return res


### PR DESCRIPTION
Support for PHP via [phpactor](https://github.com/phpactor/phpactor).

Phpactor currently provides real completion for member access (methods, properties and constants), and can provide more options in the future (e.g. new classes, local variables, etc).

Unlike most "completion backends" it does not use a database index, and relies on the package manager to locate classes - this means it is not suitable for projects using the PHP package manager ([composer](https://getcomposer.org).

It is also still under development so is potentially unstable. For this reason I don't recommend merging it yet - but just wanted to register the idea and see if it would be eligible for merging in the future.