### PR TITLE
Add to gocode CLI arguments real filename.

### DIFF
--- a/pythonx/completers/go.py
+++ b/pythonx/completers/go.py
@@ -17,7 +17,7 @@ class Go(Completor):
     def format_cmd(self):
         binary = self.get_option('gocode_binary') or 'gocode'
         return [binary, '-f=csv', '--in={}'.format(self.tempname),
-                'autocomplete', self.offset()]
+                'autocomplete', self.filename, self.offset()]
 
     def parse(self, items):
         res = []

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -10,12 +10,14 @@ def test_format_cmd(vim_mod):
     vim_mod.funcs['line2byte'] = mock.Mock(return_value=20)
     vim_mod.funcs['completor#utils#tempname'] = mock.Mock(
         return_value=b'/tmp/vJBio2A/2.vim')
+    vim_mod.current.buffer.name = '/home/vagrant/bench.vim'
     vim_mod.current.window.cursor = (1, 5)
 
     go = completor.get('go')
     go.input_data = to_unicode('self.', 'utf-8')
     assert go.format_cmd() == [
-        'gocode', '-f=csv', '--in=/tmp/vJBio2A/2.vim', 'autocomplete', 24]
+        'gocode', '-f=csv', '--in=/tmp/vJBio2A/2.vim', 'autocomplete',
+        '/home/vagrant/bench.vim', 24]
 
 
 def test_parse():


### PR DESCRIPTION
According to https://github.com/nsf/gocode/issues/461 gocode needs to have as 2nd non-flag parameters real filename. 
Should solve https://github.com/maralla/completor.vim/issues/103