### PR TITLE
Add typescript.jsx to type alias map

### DIFF
--- a/pythonx/completor/__init__.py
+++ b/pythonx/completor/__init__.py
@@ -72,6 +72,7 @@ class Completor(Base):
     _type_map = {
         b'c': b'cpp',
         b'javascript.jsx': b'javascript',
+        b'typescript.jsx': b'typescript',
         b'python.django': b'python',
     }
 


### PR DESCRIPTION
trivial addition to support `tsx` files. I guess it would be wise to either expose this mapping as an extendable `let g:` option, or by default use `b'anything.additional': b'anything'` mapping (would cover javascript, typescript and django use cases) 