### PR TITLE
Add support for Go docs

### DIFF
--- a/pythonx/completers/go.py
+++ b/pythonx/completers/go.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import subprocess
 from completor import Completor, vim
 
 logger = logging.getLogger('completor')
@@ -17,18 +18,18 @@ class Go(Completor):
 
     def format_cmd(self):
         binary = self.get_option('gocode_binary') or 'gocode'
-        return [binary, '-f=csv', '-in={}'.format(self.tempname),
+        return [binary, '-f=csv-with-package', '-in={}'.format(self.tempname),
                 'autocomplete', self.filename, self.offset()]
 
     def parse(self, items):
         res = []
         for item in items:
             parts = item.split(b',,')
-            if len(parts) < 3:
+            if len(parts) < 4:
                 continue
             res.append({
                 'word': parts[1],
                 'menu': parts[2],
-                'info': parts[2]
+                'info': subprocess.check_output(['godoc', parts[3], parts[1].decode('utf-8')])
             })
         return res

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -16,7 +16,7 @@ def test_format_cmd(vim_mod):
     go = completor.get('go')
     go.input_data = to_unicode('self.', 'utf-8')
     assert go.format_cmd() == [
-        'gocode', '-f=csv', '--in=/tmp/vJBio2A/2.vim', 'autocomplete',
+        'gocode', '-f=csv-with-package', '--in=/tmp/vJBio2A/2.vim', 'autocomplete',
         '/home/vagrant/bench.vim', 24]
 
 


### PR DESCRIPTION
What
===
Add support for retrieving the Go doc using the godoc command and displaying that in the docs preview window.

Why
===
So that the docs for an identifier, function or struct can be viewed within VIM when scrolling through the list of possible autocomplete results. As discussed in #199.

Note
===
1. The `csv-with-package` gocode format includes the package name as the last (fourth) column in the csv. The package name is required when doing the godoc lookup.
2. This works but I don't think this is in a state where it can be merged. The `format_cmd` function only lets me return a single command, and so I've hacked the godoc call into `parse`, but that means `parse` is given a list of 100 possible autocompletions, it's calling godoc 100 times. I'd like to do the godoc call only when an option is selected and the doc is actually being displayed, but I can't see how to do that.