### PR TITLE
Add alchemist.vim as Elixir completer

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ let g:completor_gocode_binary = '/path/to/gocode'
 
 Use [completor-swift](https://github.com/maralla/completor-swift).
 
-#### elixir
+#### Elixir
 
 Use [alchemist.vim](https://github.com/slashmili/alchemist.vim).
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ let g:completor_gocode_binary = '/path/to/gocode'
 
 Use [completor-swift](https://github.com/maralla/completor-swift).
 
+#### elixir
+
+Use [alchemist.vim](https://github.com/slashmili/alchemist.vim).
+
 #### other languages
 
 For other omni completions completor not natively implemented, auto completion


### PR DESCRIPTION
Now [alchemist.vim](https://github.com/slashmili/alchemist.vim) is integrated out of the box with completor.vim.

I sent this feature as PR and was merged today, as you can see here: https://github.com/slashmili/alchemist.vim/pull/136