### PR TITLE
Make javascript suggestions case insensitive

### DIFF
--- a/pythonx/completers/javascript/tern_wrapper.js
+++ b/pythonx/completers/javascript/tern_wrapper.js
@@ -187,6 +187,7 @@ function startServer(dir, config) {
       expandWordForward: false,
       inLiteral: false,
       end: {line: line, ch: col},
+      caseInsensitive: true
     };
     var file = {
       type: 'full',


### PR DESCRIPTION
Already javascript suggestions aren't case insensitive. Someone should explicitly type for example `setT` to get `setTimeout()` complete suggestion! This patch make them ignore case.