### PR TITLE
Explicitly source

### DIFF
--- a/doc/completor.txt
+++ b/doc/completor.txt
@@ -162,10 +162,10 @@ Other                                                   *completor-other*
 <
         Default: unset
 
-*g:completor_enable_{filename}*
-        Used to explicitly allow {filename} completions. If this
+*g:completor_enable_{filetype}*
+        Used to explicitly allow {filetype} completions. If this
         option is set, only file types in this list can be allowd for
-        {filename} completion.
+        {filetype} completion.
 
         For example enable neosnippet completion for only vim:
 >

--- a/doc/completor.txt
+++ b/doc/completor.txt
@@ -162,6 +162,17 @@ Other                                                   *completor-other*
 <
         Default: unset
 
+*g:completor_enable_{filename}*
+        Used to explicitly allow {filename} completions. If this
+        option is set, only file types in this list can be allowd for
+        {filename} completion.
+
+        For example enable neosnippet completion for only vim:
+>
+            let g:completor_enable_neosnippet = ['vim']
+<
+        Default: unset
+
 *g:completor_min_chars*
         Set the minimum characters to trigger completions for buffer and
         ultisnips completers.

--- a/pythonx/completor/__init__.py
+++ b/pythonx/completor/__init__.py
@@ -158,12 +158,16 @@ class Completor(Base):
 
     @property
     def disabled(self):
-        types = self.get_option('disable_{}'.format(self.filetype))
-        if isinstance(types, integer_types):
-            return bool(types)
-        if isinstance(types, (list, vim.List)):
-            return to_bytes(self.ft) in types
-        return False
+        enable_types = self.get_option('enable_{}'.format(self.filetype))
+        if isinstance(enable_types, (list, vim.List)):
+            return to_bytes(self.ft) not in enable_types
+        else:
+            disable_types = self.get_option('disable_{}'.format(self.filetype))
+            if isinstance(disable_types, integer_types):
+                return bool(disable_types)
+            if isinstance(disable_types, (list, vim.List)):
+                return to_bytes(self.ft) in disable_types
+            return False
 
     # input_data: unicode
     def match(self, input_data):


### PR DESCRIPTION
I added explicitly allowing {filetype} completions

*g:completor_enable_{filetype}*
        Used to explicitly allow {filetype} completions. If this
        option is set, only file types in this list can be allowd for
        {filetype} completion.
        For example enable neosnippet completion for only vim:
>
            let g:completor_enable_neosnippet = ['vim']

Default: unset