### PR TITLE
Windows filename

### DIFF
--- a/pythonx/completers/common/filename.py
+++ b/pythonx/completers/common/filename.py
@@ -11,7 +11,7 @@ from .utils import test_subseq, LIMIT
 
 
 logger = logging.getLogger('completor')
-PAT = re.compile('(\w+:(//?[^\s]*)?)|(</[^\s>]*>?)|(//)')
+PAT = re.compile('(\w{2,}:(//?[^\s]*)?)|(</[^\s>]*>?)|(//)')
 
 
 def gen_entry(pat, dirname, basename):
@@ -71,7 +71,10 @@ class Filename(Completor):
         \.{0,2}/|~|
 
         # '$var/'
-        \$[A-Za-z0-9{}_]+/
+        \$[A-Za-z0-9{}_]+/|
+
+        # 'c:/'
+        (?<![A-Za-z])[A-Za-z]:/
         )+
 
         # Tail part

--- a/pythonx/completers/common/filename.py
+++ b/pythonx/completers/common/filename.py
@@ -100,8 +100,6 @@ class Filename(Completor):
         """
         :param base: type unicode
         """
-        # Ignore white space.
-        base = base.split()[-1]
         logger.info('start filename parse: %s', base)
         pat = list(PAT.finditer(base))
         if pat:
@@ -116,6 +114,10 @@ class Filename(Completor):
         if not match:
             logger.info('no matches')
             return []
+
+        if match.group()[-1] == ' ':
+            return []
+
         try:
             if START_NO_DIRNAME.search(match.group()):
                 items = find(self.current_directory, match.group())

--- a/pythonx/completers/common/filename.py
+++ b/pythonx/completers/common/filename.py
@@ -78,7 +78,7 @@ class Filename(Completor):
         (?<![A-Za-z])[A-Za-z]:/|
 
         # 'dirname/'
-        [@a-zA-Z0-9(){}$ +_~.'"\x80-\xff-\[\]]+/
+        [@a-zA-Z0-9(){}+_\x80-\xff-\[\]]+/
         )+
 
         # Tail part


### PR DESCRIPTION
I allowed below format filename completion.

windows drive letter
(example) c:/

A filepath including spaces
(example) c:/Program Files/

files and directories under a directory in the current directory.
If 'dir_A' direcotry is in the current directory.
(example) dir_B/