### PR TITLE
Added option to allow disabling of placeholder generation in C/C++ code

### DIFF
--- a/doc/completor.txt
+++ b/doc/completor.txt
@@ -101,6 +101,10 @@ c/c++                                                   *completor-cpp*
             map <tab> <Plug>CompletorCppJumpToPlaceholder
             imap <tab> <Plug>CompletorCppJumpToPlaceholder
 <
+        To disable generation of placeholders on completion, use:
+>
+            let g:completor_clang_disable_placeholders = 1
+<
 go                                                      *completor-go*
         Use [gocode](https://github.com/nsf/gocode) to provide omni completions.
         To specify the gocode executable path:

--- a/pythonx/completers/cpp/__init__.py
+++ b/pythonx/completers/cpp/__init__.py
@@ -124,6 +124,9 @@ class Clang(Completor):
     def __init__(self, *args, **kwargs):
         Completor.__init__(self, *args, **kwargs)
         _inject_vim_files()
+        self.disable_placeholders = self.get_option(
+            'clang_disable_placeholders'
+        ) or 0
 
     def _gen_args(self):
         binary = self.get_option('clang_binary') or 'clang'
@@ -226,7 +229,8 @@ class Clang(Completor):
                     data['menu'] = b':'.join(parts[2:])
             func_sig = sanitize(data['menu'])
             data['abbr'] = data['word']
-            data['word'] = strip_optional(data['menu'])
+            if self.disable_placeholders != 1:
+                data['word'] = strip_optional(data['menu'])
             data['menu'] = func_sig
 
             # Show function signature in the preview window


### PR DESCRIPTION
I noticed that the automatic generation of placeholders when working on C/C++ is not ideal in my case, and added an option to turn it off. Please merge if you think it might be useful for other developers. 