### PR TITLE
fix signature bug "CallSignature object has no attribute call_name"

### DIFF
--- a/autoload/completor/action.vim
+++ b/autoload/completor/action.vim
@@ -192,8 +192,7 @@ endfunction
 function! s:is_status_consistent()
   return s:freezed_status.pos == getcurpos() &&
         \ s:freezed_status.nr == bufnr('') &&
-        \ s:freezed_status.ft == &ft &&
-        \ s:freezed_status.mode == mode()
+        \ s:freezed_status.ft == &ft
 endfunction
 
 
@@ -205,6 +204,7 @@ function! completor#action#callback(msg)
 
   if s:action ==# 'complete'
     call s:trigger_complete(a:msg)
+    call completor#do('signature')
   elseif s:action ==# 'definition'
     call s:goto_definition(a:msg)
   elseif s:action ==# 'signature'

--- a/pythonx/completers/python/python_jedi.py
+++ b/pythonx/completers/python/python_jedi.py
@@ -32,7 +32,7 @@ class JediProcessor(object):
     def jedi_context(self, args):
         self.script = self.jedi.Script(
             source=args['content'], line=args['line'] + 1,
-            column=args['col'] + 1, path=args['filename'])
+            column=args['col'], path=args['filename'])
         try:
             yield
         finally:

--- a/pythonx/completers/python/python_jedi.py
+++ b/pythonx/completers/python/python_jedi.py
@@ -89,7 +89,7 @@ class JediProcessor(object):
             params = [p.description.replace('\n', '')[6:] for p in s.params]
             yield {
                 'params': params,
-                'func': None,
+                'func': s.full_name,
                 'index': s.index or 0
             }
 

--- a/pythonx/completers/python/python_jedi.py
+++ b/pythonx/completers/python/python_jedi.py
@@ -32,7 +32,7 @@ class JediProcessor(object):
     def jedi_context(self, args):
         self.script = self.jedi.Script(
             source=args['content'], line=args['line'] + 1,
-            column=args['col'], path=args['filename'])
+            column=args['col'] + 1, path=args['filename'])
         try:
             yield
         finally:
@@ -89,7 +89,7 @@ class JediProcessor(object):
             params = [p.description.replace('\n', '')[6:] for p in s.params]
             yield {
                 'params': params,
-                'func': s.call_name,
+                'func': None,
                 'index': s.index or 0
             }
 

--- a/pythonx/completers/python/python_jedi.py
+++ b/pythonx/completers/python/python_jedi.py
@@ -9,7 +9,7 @@ import logging
 import os.path
 import sys
 
-log_file = os.path.join(os.path.dirname(__file__), 'completor_python.log')
+log_file = '/tmp/completor_python.log'
 logger = logging.getLogger('python-jedi')
 handler = logging.FileHandler(log_file, delay=1)
 handler.setLevel(logging.INFO)

--- a/pythonx/completor/__init__.py
+++ b/pythonx/completor/__init__.py
@@ -225,6 +225,8 @@ class Completor(Base):
             data = _unicode(data)
         if action == 'complete':
             return self.do_complete(data)
+        if 'signature' in action:
+            action = 'signature'
         try:
             return getattr(self, 'on_' + action)(data)
         except AttributeError:

--- a/pythonx/completor/_log.py
+++ b/pythonx/completor/_log.py
@@ -3,7 +3,7 @@
 import os
 
 _dir = os.path.dirname(__file__)
-_file = os.path.join(os.path.dirname(_dir), 'completor.log')
+_file = '/tmp/completor.log'
 
 
 _log_filter = {}


### PR DESCRIPTION
With jedi, signature doesn't work correctly with latest version because `call_name` does not set. I just set call_name as None to avoid the bug. 

    on_signature <CallSignature: arange index=0 params=[start, stop, step, , dtype]>
    error 'CallSignature' object has no attribute 'call_name'
    (<class 'AttributeError'>, AttributeError("'CallSignature' object has no attribute 'call_name'"), <traceback object at 0x7fd0969deac8>)Traceback (most recent call last):
      File "/home/zenbook/.cache/dein/.cache/.vimrc/.dein/pythonx/completers/python/python_jedi.py", line 129, in run
        ret = processor.process(args)
      File "/home/zenbook/.cache/dein/.cache/.vimrc/.dein/pythonx/completers/python/python_jedi.py", line 63, in process
        return list(func())
      File "/home/zenbook/.cache/dein/.cache/.vimrc/.dein/pythonx/completers/python/python_jedi.py", line 99, in on_signature
        'func': s.call_name,
