### PR TITLE
Remove <cr> from tab select example

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ This is simple *.tern-project* file:
 ```vim
 inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
 inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
-inoremap <expr> <cr> pumvisible() ? "\<C-y>\<cr>" : "\<cr>"
+inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<cr>"
 ```
 
 #### Use Tab to trigger completion (disable auto trigger)


### PR DESCRIPTION
I've been using the configuration in the example in the "Use Tab to select completion" section. I've found the `<cr>` on the last inoremap is counterintuitive. This PR proposes removing it.

The newline is not what I expect when hit enter after tabbing to select the completion I want. I almost always have to delete the newline to get back to the end of the inserted completion, which is where I want to be.

This modified behavior makes the `<cr>` match the behavior in other editors like Atom and VS Code.