### PR TITLE
Fix completeopt not being restored after completion

### DIFF
--- a/autoload/completor.vim
+++ b/autoload/completor.vim
@@ -74,6 +74,7 @@ function! s:set_events()
       autocmd TextChangedI * call s:on_text_change()
       autocmd InsertCharPre * call s:on_insert_char_pre()
     endif
+    autocmd InsertLeave * call completor#action#_on_insert_leave()
     autocmd! CompleteDone * call completor#action#_on_complete_done()
   augroup END
 endfunction

--- a/autoload/completor.vim
+++ b/autoload/completor.vim
@@ -74,11 +74,7 @@ function! s:set_events()
       autocmd TextChangedI * call s:on_text_change()
       autocmd InsertCharPre * call s:on_insert_char_pre()
     endif
-    if get(g:, 'completor_auto_close_doc', 1)
-      autocmd! CompleteDone * call completor#action#_on_complete_done()
-    endif
-    autocmd InsertEnter * call completor#action#_on_insert_enter()
-    autocmd InsertLeave * call completor#action#_on_insert_leave()
+    autocmd! CompleteDone * call completor#action#_on_complete_done()
   augroup END
 endfunction
 

--- a/autoload/completor/action.vim
+++ b/autoload/completor/action.vim
@@ -31,6 +31,14 @@ function! completor#action#_on_complete_done()
 endfunction
 
 
+function! completor#action#_on_insert_leave()
+  if exists('s:cot')
+    " Restore cot.
+    let &cot = s:cot
+  endif
+endfunction
+
+
 function! s:trigger_complete(completions)
   " Record cot.
   if !exists('s:cot')

--- a/autoload/completor/action.vim
+++ b/autoload/completor/action.vim
@@ -17,7 +17,12 @@ endfunction
 
 
 function! completor#action#_on_complete_done()
-  if pumvisible() == 0
+  " Restore cot.
+  if exists('s:cot')
+    let &cot = s:cot
+  endif
+
+  if get(g:, 'completor_auto_close_doc', 1) && pumvisible() == 0
     try
       pclose
     catch
@@ -26,24 +31,13 @@ function! completor#action#_on_complete_done()
 endfunction
 
 
-function! completor#action#_on_insert_enter()
+function! s:trigger_complete(completions)
+  " Record cot.
   if !exists('s:cot')
-    " Record cot.
     let s:cot = &cot
   endif
   let &cot = get(g:, 'completor_complete_options', &cot)
-endfunction
 
-
-function! completor#action#_on_insert_leave()
-  if exists('s:cot')
-    " Restore cot.
-    let &cot = s:cot
-  endif
-endfunction
-
-
-function! s:trigger_complete(completions)
   let s:completions = a:completions
   if empty(s:completions) | return | endif
   let startcol = completor#action#completefunc(1, '')

--- a/plugin/completor.vim
+++ b/plugin/completor.vim
@@ -50,7 +50,6 @@ let g:completor_filetype_map = extend(s:default_type_map, get(g:, 'completor_fil
 
 func s:init()
   call completor#enable_autocomplete()
-  call completor#action#_on_insert_enter()
 endfunc
 
 


### PR DESCRIPTION
According to the documentation:
```
"[...] The config `completeopt` will be 
       overwritten by the value when the completion is triggered and restored
       after completion done."
```

This is not what happens in reality though, as `completeopt` is overwritten when entering insert mode, and only restored after leaving it, completely breaking the use of Vim's native completion with the user's `completeopt`.

This pull request fixes this behavior, adapting it to what is described in the documentation and to what is considered a better user experience.