### PR TITLE
fix side effect from python support check

### DIFF
--- a/plugin/completor.vim
+++ b/plugin/completor.vim
@@ -9,7 +9,7 @@ function! s:restore_cpo()
 endfunction
 
 function! s:has_features()
-  return (has('python') || has('python3')) &&
+  return (has('pythonx') || has('python3') || has('python')) &&
         \ (has('job') && has('timers') || has('nvim')) &&
         \ has('lambda')
 endfunction


### PR DESCRIPTION
has('python') caused vim to initialize with python 2, disabling python 3
altogether.

- Reverse the check, such that python 3 is used if available.
- Before that, check for pythonx, which initializes according to pyxversion
  option if availabe

See :h has-python for more details.