### PR TITLE
add g:completor_filename_completion_in_only_comment

### DIFF
--- a/doc/completor.txt
+++ b/doc/completor.txt
@@ -235,7 +235,10 @@ Other                                                   *completor-other*
             vsplit: same as :vsplit.
             tab:    same as :tab split
 
+*g:completor_filename_completion_in_only_comment*
+        This option allows filename completion in only comment or strings.
 
+        Default: 1
 ==============================================================================
 5. Write a new completer                                *completor-writing*
 

--- a/plugin/completor.vim
+++ b/plugin/completor.vim
@@ -47,6 +47,7 @@ let g:completor_doc_position = get(g:, 'completor_doc_position', 'bottom')
 let g:completor_def_split = get(g:, 'completor_def_split', '')
 let g:completor_complete_options = get(g:, 'completor_complete_options', 'menuone,noselect,preview')
 let g:completor_filetype_map = extend(s:default_type_map, get(g:, 'completor_filetype_map', {}))
+let g:completor_filename_completion_in_only_comment = get(g:, 'completor_filename_completion_in_only_comment', 1)
 
 
 func s:init()

--- a/pythonx/completers/common/filename.py
+++ b/pythonx/completers/common/filename.py
@@ -97,9 +97,12 @@ class Filename(Completor):
     ident = r"""[@a-zA-Z0-9(){}$+_~.'"\x80-\xff-\[\]]*"""
 
     def match(self, input_data):
-        if self.is_comment_or_string():
+        if Completor.get_option('filename_completion_in_only_comment'):
+            if self.is_comment_or_string():
+                return bool(self.trigger.search(input_data))
+            return False
+        else:
             return bool(self.trigger.search(input_data))
-        return False
 
     def _path(self, base):
         pat = list(PAT.finditer(base))


### PR DESCRIPTION
I added g:completor_filename_completion_in_only_comment option, which allow a user to select filename completion in only comment and strings or not.