### PR TITLE
Fix "unsafe" call to "popup#safe_hide()"

### DIFF
--- a/autoload/completor/daemon.vim
+++ b/autoload/completor/daemon.vim
@@ -12,7 +12,9 @@ endfunction
 
 
 function! s:on_exit(name, job_id, status)
-  call completor#popup#safe_hide()
+  if completor#support_popup()
+    call completor#popup#hide()
+  endif
   call completor#utils#on_exit()
 endfunction
 


### PR DESCRIPTION
Lower version Vim ( < 8.1 ) does not understand "literal-dict" like "#{}" definition