### PR TITLE
Use preview window to show docs

### DIFF
--- a/autoload/completor/action.vim
+++ b/autoload/completor/action.vim
@@ -172,23 +172,6 @@ function! s:call_signatures(items)
 endfunction
 
 
-function! s:open_doc_window()
-  let n = bufnr('__doc__')
-  let direction = get(s:DOC_POSITION, g:completor_doc_position, s:DOC_POSITION.bottom)
-  if n > 0
-    let i = index(tabpagebuflist(tabpagenr()), n)
-    if i >= 0
-      " Just jump to the doc window
-      silent execute (i + 1).'wincmd w'
-    else
-      silent execute direction.' sbuffer '.n
-    endif
-  else
-    silent execute direction.' split __doc__'
-  endif
-endfunction
-
-
 function! s:show_doc(items)
   if empty(a:items)
     return
@@ -197,14 +180,21 @@ function! s:show_doc(items)
   if empty(doc)
     return
   endif
-  call s:open_doc_window()
 
-  setlocal modifiable noswapfile buftype=nofile
+  let direction = get(s:DOC_POSITION, g:completor_doc_position, s:DOC_POSITION.bottom)
+  let height = min([len(doc), &previewheight])
+  silent execute direction.' pedit +resize'.height.' __doc__'
+
+  wincmd P
+  setlocal modifiable noreadonly
   silent normal! ggdG
   silent $put=doc
   silent normal! 1Gdd
-  setlocal nomodifiable nomodified foldlevel=200
+  setlocal nomodifiable nomodified readonly
+  setlocal noswapfile buftype=nofile nobuflisted bufhidden=wipe
+  setlocal foldlevel=200
   nnoremap <buffer> q ZQ
+  wincmd p
 endfunction
 
 


### PR DESCRIPTION
The preview window is designed for this task, with handy commands for jumping into it and closing it, all ready to go. I've also enforced some more strict "this is not a real file" settings, left the cursor where it was before the window was opened, and shrunk the opened preview window to a minimal size.

Happy to set up options for any of this functionality, if requested.