### PR TITLE
add vim.Dictionary in type check of omnifunc result.

### DIFF
--- a/pythonx/completers/common/omni.py
+++ b/pythonx/completers/common/omni.py
@@ -65,7 +65,7 @@ class Omni(Completor):
                 return []
             res = omnifunc(0, to_bytes(base, get_encoding())[codepoint:])
             for i, e in enumerate(res):
-                if not isinstance(e, dict, vim.Dictionary):
+                if not isinstance(e, (dict, vim.Dictionary)):
                     res[i] = {'word': e}
                 res[i]['offset'] = codepoint
             return res

--- a/pythonx/completers/common/omni.py
+++ b/pythonx/completers/common/omni.py
@@ -65,7 +65,7 @@ class Omni(Completor):
                 return []
             res = omnifunc(0, to_bytes(base, get_encoding())[codepoint:])
             for i, e in enumerate(res):
-                if not isinstance(e, dict):
+                if not isinstance(e, dict, vim.Dictionary):
                     res[i] = {'word': e}
                 res[i]['offset'] = codepoint
             return res


### PR DESCRIPTION
bugfix - missing vim.Dictionary type check in omnifunc result, causes a "using Dictionary as string" error in vim.