### PR TITLE
Fixing problem with json dumping failure of PosixPath.

### DIFF
--- a/pythonx/completers/python/python_jedi.py
+++ b/pythonx/completers/python/python_jedi.py
@@ -3,11 +3,12 @@
 from __future__ import print_function
 
 import argparse
-import json
 import contextlib
+import json
 import logging
 import os.path
 import sys
+from pathlib import Path
 
 log_file = os.path.join(os.path.dirname(__file__), 'completor_python.log')
 logger = logging.getLogger('python-jedi')
@@ -135,6 +136,10 @@ def run(jedi):
         except Exception as e:
             logger.exception(e)
             ret = []
+        for idx, line in enumerate(ret):
+            for key, value in line.items():
+                if isinstance(value, Path):
+                    line[key] = str(line[key])
         write(json.dumps(ret))
 
 

--- a/pythonx/completers/python/python_jedi.py
+++ b/pythonx/completers/python/python_jedi.py
@@ -3,12 +3,11 @@
 from __future__ import print_function
 
 import argparse
-import contextlib
 import json
+import contextlib
 import logging
 import os.path
 import sys
-from pathlib import Path
 
 log_file = os.path.join(os.path.dirname(__file__), 'completor_python.log')
 logger = logging.getLogger('python-jedi')
@@ -87,7 +86,7 @@ class JediProcessor(object):
                 item['text'] = 'Builtin {}'.format(item['text'])
             else:
                 item.update({
-                    'filename': d.module_path,
+                    'filename': str(d.module_path),
                     'lnum': d.line,
                     'col': d.column + 1,
                     'name': d.name,
@@ -136,10 +135,6 @@ def run(jedi):
         except Exception as e:
             logger.exception(e)
             ret = []
-        for idx, line in enumerate(ret):
-            for key, value in line.items():
-                if isinstance(value, Path):
-                    line[key] = str(line[key])
         write(json.dumps(ret))
 
 


### PR DESCRIPTION
Currently `jump-to-definition` isn't working properly with python3 because PosixPath cannot be converted into json format directly.

This is a quick patch to fix it.

```
[I 210128 20:25:06 __init__:96] Exception e=TypeError('Object of type PosixPath is not JSON serializable')
```

It was hard to find this bug because json dump failure didn't have any output to logger. I think exception handling of json dumping failure should be added too.