### PR TITLE
Do not show oneself in candidates in Buffer completion

### DIFF
--- a/pythonx/completers/common/buffer.py
+++ b/pythonx/completers/common/buffer.py
@@ -101,6 +101,10 @@ class Buffer(Completor):
         for token, factor in token_store.search(identifier):
             if token == identifier:
                 continue
+            line = self.cursor_line
+            column = len(self.input_data)
+            if (identifier + line[column:])[:len(token)] == token:
+                continue
             res.add((token, factor))
             if len(res) >= LIMIT:
                 break


### PR DESCRIPTION
Completor also shows the same candidate as the current status.
![image](https://user-images.githubusercontent.com/1556311/116543712-27b72780-a929-11eb-8906-1acdbbe98764.png)
This confuse, especially,  in buffer completions with multibyte language.
That frequently happens in multibyte languages.

I prohibited buffer completion from doing it.
