### PR TITLE
no complete last characters of candidate when there are the same char…

### DIFF
--- a/pythonx/completor/compat.py
+++ b/pythonx/completor/compat.py
@@ -26,3 +26,10 @@ def to_unicode(x, charset):
     if not isinstance(x, bytes):
         return text_type(x)
     return x.decode(charset)
+
+
+def is_bytes(s):
+    if isinstance(s, text_type):
+        return False
+    else:
+        return True


### PR DESCRIPTION
I make completor not to complete all characters of a candidate when there is already same characters after cursor.

For example, there is cursor in front of bbb_ccc and complete "aaa_bbb_ccc". the result is aaa_bbb_cccbbb_ccc.
I fixed it to be aaa_bbb_ccc