### PR TITLE
Mention completor-vsnip for vim-vsnip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ completed.
 This is the fallback completer. When no semantic completer found the buffer
 completer will be used and will complete based on the current buffers.
 
-#### Ultisnips and neosnippet
+#### Snippets
 
-Ultisnips is supported by default. If [ultisnips](https://github.com/SirVer/ultisnips) is installed,
+Ultisnips: is supported by default. If [ultisnips](https://github.com/SirVer/ultisnips) is installed,
 the snips candidates will show on the completion popup menu.
 
-Use this plugin [completor-neosnippet](https://github.com/maralla/completor-neosnippet) for neosnippet support.
+neosnippet: Need to install [completor-neosnippet](https://github.com/maralla/completor-neosnippet) for neosnippet support.
+
+vim-vsnip: Need to install [completor-vsnip](https://github.com/phongnh/completor-vsnip) for vim-vsnip support.
 
 #### Neoinclude
 


### PR DESCRIPTION
Hi @maralla,

I added a completor plugin [completor-vsnip](https://github.com/phongnh/completor-vsnip) for [vim-vsnip](https://github.com/hrsh7th/vim-vsnip) support. I just wanted to add it to README for someone who maybe need it.

Please let me know if I need to update something to get PR merged, thanks.